### PR TITLE
skip serialize when the key is tableCellRowHeaders, closes #18

### DIFF
--- a/js/server/automation-tree.js
+++ b/js/server/automation-tree.js
@@ -294,7 +294,7 @@ class AutomationTree {
       for (let prop of props) { // Get all keys
         // For unknown reasons, accessing tableCellRowHeaders is breaking the code.
         // https://github.com/google/automation-inspector/issues/18
-        // TODO: investigate on why it happens.
+        // TODO: investigate why it happens.
         if (prop === 'tableCellRowHeaders') continue;
         const val = from[prop],
           type = typeof val;

--- a/js/server/automation-tree.js
+++ b/js/server/automation-tree.js
@@ -292,6 +292,10 @@ class AutomationTree {
 
     const serialize = (from, to, props) => {
       for (let prop of props) { // Get all keys
+        // For unknown reasons, accessing tableCellRowHeaders is breaking the code.
+        // https://github.com/google/automation-inspector/issues/18
+        // TODO: investigate on why it happens.
+        if (prop === 'tableCellRowHeaders') continue;
         const val = from[prop],
           type = typeof val;
 


### PR DESCRIPTION
As #18 mentioned, getting ReferenceError: ids is not defined after downloading the extension and click the extension icon when viewing a webpage.
![image](https://user-images.githubusercontent.com/10692276/60964209-11a43580-a356-11e9-9034-9b4a5273de5f.png)

For currently unknown(to me) reason, serialize breaks when the key is `tableCellRowHeaders`(#18 provides logs that give evidence).

After this fix, this extension works well on my side.
![image](https://user-images.githubusercontent.com/10692276/60965032-24b80500-a358-11e9-9362-e02b32ed9d71.png)
